### PR TITLE
Fixed bug when Rack::OAuth2.debug! is called after code like this

### DIFF
--- a/lib/rack/oauth2.rb
+++ b/lib/rack/oauth2.rb
@@ -43,8 +43,8 @@ module Rack
       _http_client_ = HTTPClient.new(
         :agent_name => agent_name
       )
-      _http_client_.request_filter << Debugger::RequestFilter.new if debugging?
       http_config.try(:call, _http_client_)
+      _http_client_.request_filter << Debugger::RequestFilter.new if debugging?
       _http_client_
     end
     def self.http_config(&block)


### PR DESCRIPTION
Rack::OAuth2.http_config do |h|
  h.request_filter << Rack::OAuth2::AccessToken::Authenticator.new(token)
end

Debug information was output with no authentication headers.
