### PR TITLE
Switch to multi_json instead of using the json gem explicitly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       attr_required (>= 0.0.5)
       httpclient (>= 2.2.0.2)
       i18n
-      json (>= 1.4.3)
+      multi_json (>= 1.3.6)
       rack (>= 1.1)
 
 GEM
@@ -15,7 +15,7 @@ GEM
     activesupport (3.2.8)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    addressable (2.2.8)
+    addressable (2.3.2)
     attr_required (0.0.5)
     bouncy-castle-java (1.5.0146.1)
     configatron (2.9.1)
@@ -26,11 +26,10 @@ GEM
     crack (0.3.1)
     diff-lcs (1.1.3)
     hashie (1.2.0)
-    httpclient (2.2.5)
+    httpclient (2.2.7)
     i18n (0.6.0)
     jruby-openssl (0.7.7)
       bouncy-castle-java (>= 1.5.0146.1)
-    json (1.7.4)
     multi_json (1.3.6)
     rack (1.4.1)
     rake (0.9.2.2)
@@ -41,9 +40,9 @@ GEM
     rspec-core (2.11.1)
     rspec-expectations (2.11.2)
       diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.1)
-    webmock (1.8.8)
-      addressable (~> 2.2.8)
+    rspec-mocks (2.11.2)
+    webmock (1.8.9)
+      addressable (>= 2.2.7)
       crack (>= 0.1.7)
     yamler (0.1.0)
 

--- a/lib/rack/oauth2.rb
+++ b/lib/rack/oauth2.rb
@@ -1,5 +1,5 @@
 require 'rack'
-require 'json'
+require 'multi_json'
 require 'httpclient'
 require 'logger'
 require 'active_support/core_ext'

--- a/lib/rack/oauth2/client.rb
+++ b/lib/rack/oauth2/client.rb
@@ -89,7 +89,7 @@ module Rack
       end
 
       def handle_success_response(response)
-        token_hash = JSON.parse(response.body).with_indifferent_access
+        token_hash = MultiJson.load(response.body).with_indifferent_access
         case token_hash[:token_type].try(:downcase)
         when 'bearer'
           AccessToken::Bearer.new(token_hash)
@@ -100,15 +100,15 @@ module Rack
         else
           raise 'Unknown Token Type'
         end
-      rescue JSON::ParserError
+      rescue MultiJson::DecodeError
         # NOTE: Facebook support (They don't use JSON as token response)
         AccessToken::Legacy.new Rack::Utils.parse_nested_query(response.body).with_indifferent_access
       end
 
       def handle_error_response(response)
-        error = JSON.parse(response.body).with_indifferent_access
+        error = MultiJson.load(response.body).with_indifferent_access
         raise Error.new(response.status, error)
-      rescue JSON::ParserError
+      rescue MultiJson::DecodeError
         raise Error.new(response.status, :error => 'Unknown', :error_description => response.body)
       end
     end

--- a/lib/rack/oauth2/server/abstract/error.rb
+++ b/lib/rack/oauth2/server/abstract/error.rb
@@ -28,7 +28,7 @@ module Rack
             yield response if block_given?
             unless response.redirect?
               response.header['Content-Type'] = 'application/json'
-              response.write Util.compact_hash(protocol_params).to_json
+              response.write MultiJson.dump(Util.compact_hash(protocol_params))
             end
             response.finish
           end

--- a/lib/rack/oauth2/server/token.rb
+++ b/lib/rack/oauth2/server/token.rb
@@ -64,7 +64,7 @@ module Rack
 
           def finish
             attr_missing!
-            write Util.compact_hash(protocol_params).to_json
+            write MultiJson.dump(Util.compact_hash(protocol_params))
             header['Content-Type'] = 'application/json'
             header['Cache-Control'] = 'no-store'
             header['Pragma'] = 'no-cache'

--- a/rack-oauth2.gemspec
+++ b/rack-oauth2.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.add_runtime_dependency "rack", ">= 1.1"
-  s.add_runtime_dependency "json", ">= 1.4.3"
+  s.add_runtime_dependency "multi_json", ">= 1.3.6"
   s.add_runtime_dependency "httpclient", ">= 2.2.0.2"
   s.add_runtime_dependency "activesupport", ">= 2.3"
   s.add_runtime_dependency "i18n"

--- a/spec/rack/oauth2/debugger/request_filter_spec.rb
+++ b/spec/rack/oauth2/debugger/request_filter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Rack::OAuth2::Debugger::RequestFilter do
   let(:resource_endpoint) { 'https://example.com/resources' }
   let(:request) { HTTP::Message.new_request(:get, URI.parse(resource_endpoint)) }
-  let(:response) { HTTP::Message.new_response({:hello => 'world'}.to_json) }
+  let(:response) { HTTP::Message.new_response(MultiJson.dump({:hello => 'world'})) }
   let(:request_filter) { Rack::OAuth2::Debugger::RequestFilter.new }
 
   describe '#filter_request' do


### PR DESCRIPTION
Switch `JSON.parse` and `to_json` calls to `MultiJson` method calls. All specs pass. Resolves #13.
