### PR TITLE
Restore from Rack breaking API change

### DIFF
--- a/lib/rack/oauth2/server/resource/mac.rb
+++ b/lib/rack/oauth2/server/resource/mac.rb
@@ -24,7 +24,7 @@ module Rack
             end
 
             def oauth2?
-              @auth_header.provided? && @auth_header.scheme == :mac
+              @auth_header.provided? && @auth_header.scheme.to_sym == :mac
             end
           end
         end


### PR DESCRIPTION
Now all methods of Rack::Auth::AbstractRequest returns strings, so, let's use to_sym for comparison
https://github.com/rack/rack/commit/0c76175fcccad74ba2f991c487d3669c28a297c8

Please check other comparisons in your code
Here you use to_s ... WHY!? :scream:
https://github.com/nov/rack-oauth2/blob/master/lib/rack/oauth2/server/resource/bearer.rb
