### PR TITLE
Ext. verifier specific reading request body

### DIFF
--- a/lib/rack/oauth2/access_token/mac.rb
+++ b/lib/rack/oauth2/access_token/mac.rb
@@ -20,8 +20,10 @@ module Rack
         end
 
         def verify!(request)          
-          body = request.body.read
           if self.ext_verifier.present?
+            body = request.body.read
+            request.body.rewind # for future use
+
             self.ext_verifier.new(
               :raw_body => body,
               :algorithm => self.mac_algorithm


### PR DESCRIPTION
So, when i have no external verifier, while i process token, MAC class read request body. 

My sinatra app, is next app in stack (MAC.middleware -> Sinatra.app), so MAC read body, and not rewind it back

And in my Sinatra app i have no post params (if it was POST request)
I can hack and in my authenticator ask for request params, but it's seems not correct

@nov what do u think?
