### PR TITLE
Allow alternative names for the OAuth access token type name

### DIFF
--- a/lib/rack/oauth2/server/resource/bearer.rb
+++ b/lib/rack/oauth2/server/resource/bearer.rb
@@ -27,7 +27,7 @@ module Rack
             end
 
             def access_token_in_header
-              if @auth_header.provided? && @auth_header.scheme.to_s == 'bearer'
+              if @auth_header.provided? && %w[bearer oauth oauth2 token].include?(@auth_header.scheme.to_s)
                 @auth_header.params
               else
                 nil

--- a/spec/rack/oauth2/server/resource/bearer_spec.rb
+++ b/spec/rack/oauth2/server/resource/bearer_spec.rb
@@ -54,8 +54,25 @@ describe Rack::OAuth2::Server::Resource::Bearer do
 
   context 'when valid_token is given' do
     context 'when token is in Authorization header' do
-      let(:env) { Rack::MockRequest.env_for('/protected_resource', 'HTTP_AUTHORIZATION' => 'Bearer valid_token') }
-      it_behaves_like :authenticated_bearer_request
+      context 'when the OAuth access token type name is set to "Bearer"' do
+        let(:env) { Rack::MockRequest.env_for('/protected_resource', 'HTTP_AUTHORIZATION' => 'Bearer valid_token') }
+        it_behaves_like :authenticated_bearer_request
+      end
+
+      context 'when the OAuth access token type name is set to "Oauth"' do
+        let(:env) { Rack::MockRequest.env_for('/protected_resource', 'HTTP_AUTHORIZATION' => 'Oauth valid_token') }
+        it_behaves_like :authenticated_bearer_request
+      end
+
+      context 'when the OAuth access token type name is set to "Oauth2"' do
+        let(:env) { Rack::MockRequest.env_for('/protected_resource', 'HTTP_AUTHORIZATION' => 'Oauth2 valid_token') }
+        it_behaves_like :authenticated_bearer_request
+      end
+
+      context 'when the OAuth access token type name is set to "Token"' do
+        let(:env) { Rack::MockRequest.env_for('/protected_resource', 'HTTP_AUTHORIZATION' => 'Token valid_token') }
+        it_behaves_like :authenticated_bearer_request
+      end
     end
 
     context 'when token is in params' do


### PR DESCRIPTION
This ensures backward-compatibility with earlier version of the
"Bearer Token Usage" draft
(http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-23#appendix-B) when the
OAuth access token type name was named "Oauth2" as well as with
earlier / "exotic" implementation of the "Bearer Token Usage draft" where the
OAuth access token type name could be "Oauth" or "Token".
