### PR TITLE
Make redirect_uri static

### DIFF
--- a/lib/rack/oauth2/util.rb
+++ b/lib/rack/oauth2/util.rb
@@ -41,13 +41,7 @@ module Rack
         end
 
         def uri_match?(base, given)
-          base = parse_uri(base)
-          given = parse_uri(given)
-          base.path = '/' if base.path.blank?
-          given.path = '/' if given.path.blank?
-          [:scheme, :host, :port].all? do |key|
-            base.send(key) == given.send(key)
-          end && /^#{base.path}/ =~ given.path
+          base == given
         rescue
           false
         end


### PR DESCRIPTION
Flexible redirect_uri is root of lots of Facebook vulnerabilities and there is 0 reasons to have it. Every app must set static redirect_uri endpoint. If you need more proofs how buggy this behavior is i can provide links to my blog posts. Cheers
