### PR TITLE
Fix error when Authorization header is blank

### DIFF
--- a/lib/rack/oauth2/server/resource/bearer.rb
+++ b/lib/rack/oauth2/server/resource/bearer.rb
@@ -27,7 +27,7 @@ module Rack
             end
 
             def access_token_in_header
-              if @auth_header.provided? && @auth_header.scheme.to_s == 'bearer'
+              if @auth_header.provided? && !@auth_header.parts.first.nil? && @auth_header.scheme.to_s == 'bearer'
                 @auth_header.params
               else
                 nil

--- a/spec/rack/oauth2/server/resource/bearer_spec.rb
+++ b/spec/rack/oauth2/server/resource/bearer_spec.rb
@@ -42,14 +42,17 @@ describe Rack::OAuth2::Server::Resource::Bearer do
       access_token.should be_nil
     end
   end
-
-  context 'when no access token is given' do
-    let(:env) { Rack::MockRequest.env_for('/protected_resource') }
+  shared_examples_for :skipped_authentication_request do
     it 'should skip OAuth 2.0 authentication' do
       status, header, response = request
       status.should == 200
       access_token.should be_nil
     end
+  end
+
+  context 'when no access token is given' do
+    let(:env) { Rack::MockRequest.env_for('/protected_resource') }
+    it_behaves_like :skipped_authentication_request
   end
 
   context 'when valid_token is given' do
@@ -62,6 +65,11 @@ describe Rack::OAuth2::Server::Resource::Bearer do
       let(:env) { Rack::MockRequest.env_for('/protected_resource', :params => {:access_token => 'valid_token'}) }
       it_behaves_like :authenticated_bearer_request
     end
+  end
+
+  context 'when invalid authorization header is given' do
+    let(:env) { Rack::MockRequest.env_for('/protected_resource', 'HTTP_AUTHORIZATION' => '') }
+    it_behaves_like :skipped_authentication_request
   end
 
   context 'when invalid_token is given' do


### PR DESCRIPTION
Hi nov. Great work on this library. I have a fix for a small bug @andreas-kupries found.

If a request is made to a bearer token resource with a blank
(but present) Authorization: header, rack-oauth2 will cause
rack to throw a "undefined method `downcase' for nil:NilClass"
error. This checks for a nil value and treats the request as if
the header was not provided, preventing the error.
