### PR TITLE
Set correct error message when no access token is provided

### DIFF
--- a/lib/rack/oauth2/server/resource/bearer.rb
+++ b/lib/rack/oauth2/server/resource/bearer.rb
@@ -16,6 +16,8 @@ module Rack
               @access_token = case Array(tokens).size
               when 1
                 tokens.first
+              when 0
+                invalid_request!('Either Authorization header or payload must include access token.')
               else
                 invalid_request!('Both Authorization header and payload includes access token.')
               end

--- a/spec/rack/oauth2/server/resource/bearer_spec.rb
+++ b/spec/rack/oauth2/server/resource/bearer_spec.rb
@@ -120,4 +120,36 @@ describe Rack::OAuth2::Server::Resource::Bearer do
       it_behaves_like :bad_bearer_request
     end
   end
+
+  describe 'Request object' do
+    let(:request_object) { Rack::OAuth2::Server::Resource::Bearer::Request.new env }
+    describe '#setup!' do
+      context 'when no access token is given' do
+        let(:env) { Rack::MockRequest.env_for('/protected_resource') }
+        it 'should set the correct error message' do
+          expect { request_object.setup! }.to raise_error(
+            Rack::OAuth2::Server::Resource::BadRequest,
+            'invalid_request :: Either Authorization header or payload must include access token.'
+          )
+        end
+      end
+
+      context 'when token is in Authorization header and params' do
+        let(:env) do
+          Rack::MockRequest.env_for(
+            '/protected_resource',
+            'HTTP_AUTHORIZATION' => 'Bearer valid_token',
+            :params => {:access_token => 'valid_token'}
+          )
+        end
+
+        it 'should set the correct error message' do
+          expect { request_object.setup! }.to raise_error(
+            Rack::OAuth2::Server::Resource::BadRequest,
+            'invalid_request :: Both Authorization header and payload includes access token.'
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When working with the request object directly, it is possible to call `#setup!` even if no token has been provided.  (Normally, this would cause `#oauth2?` to return false, and thus `#setup!` would not be called.)  Working directly with the request object may or may not be the best idea, but it would probably be nice to return the correct error message, regardless.
