### PR TITLE
RFC 6750-Compliant HTTP error responses

### DIFF
--- a/spec/rack/oauth2/server/token_spec.rb
+++ b/spec/rack/oauth2/server/token_spec.rb
@@ -72,10 +72,13 @@ describe Rack::OAuth2::Server::Token do
   end
 
   Rack::OAuth2::Server::Token::ErrorMethods::DEFAULT_DESCRIPTION.each do |error, default_message|
-    status = if error == :invalid_client
-      401
-    else
+    status = case error
+    when :invalid_request,:unsupported_grant_type
       400
+    when :invalid_scope
+      403
+    else
+      401
     end
     context "when #{error}" do
       let(:app) do


### PR DESCRIPTION
The HTTP error responses being returned by rack-oauth2 at present do not align with the suggestions in RFC-6750 section 3.1 (http://tools.ietf.org/html/rfc6750#section-3.1).

With this PR, the error codes returned are in better alignment with those suggested by the RFC.
