### PR TITLE
⚠️ `&' interpreted as argument prefix

### DIFF
--- a/lib/rack/oauth2/server/resource.rb
+++ b/lib/rack/oauth2/server/resource.rb
@@ -9,7 +9,7 @@ module Rack
         def initialize(app, realm = nil, &authenticator)
           @app = app
           @realm = realm
-          super &authenticator
+          super(&authenticator)
         end
 
         def call(env)


### PR DESCRIPTION
Here's a patch fixing a trivial Ruby warning.