### PR TITLE
Read token from Bearer cookie

### DIFF
--- a/lib/rack/oauth2/server/resource/bearer.rb
+++ b/lib/rack/oauth2/server/resource/bearer.rb
@@ -13,10 +13,10 @@ module Rack
           class Request < Resource::Request
             def setup!
               tokens = [access_token_in_cookie, access_token_in_header, access_token_in_payload].compact
-              if tokens.kind_of?(Array) && tokens.size > 0
-                @access_token = tokens.first
+              @access_token = if Array(tokens).size > 0
+                tokens.first
               else
-                @access_token = invalid_request!('Both Authorization header and payload includes access token.')
+                invalid_request!('Both Authorization header and payload includes access token.')
               end
               self
             end

--- a/lib/rack/oauth2/server/resource/bearer.rb
+++ b/lib/rack/oauth2/server/resource/bearer.rb
@@ -12,18 +12,17 @@ module Rack
 
           class Request < Resource::Request
             def setup!
-              tokens = [access_token_in_header, access_token_in_payload].compact
-              @access_token = case Array(tokens).size
-              when 1
-                tokens.first
+              tokens = [access_token_in_cookie, access_token_in_header, access_token_in_payload].compact
+              if tokens.kind_of?(Array) && tokens.size > 0
+                @access_token = tokens.first
               else
-                invalid_request!('Both Authorization header and payload includes access token.')
+                @access_token = invalid_request!('Both Authorization header and payload includes access token.')
               end
               self
             end
 
             def oauth2?
-              (access_token_in_header || access_token_in_payload).present?
+              (access_token_in_cookie || access_token_in_header || access_token_in_payload).present?
             end
 
             def access_token_in_header
@@ -36,6 +35,10 @@ module Rack
 
             def access_token_in_payload
               params['access_token']
+            end
+
+            def access_token_in_cookie
+              cookies['Bearer']
             end
           end
         end

--- a/spec/rack/oauth2/server/resource/bearer_spec.rb
+++ b/spec/rack/oauth2/server/resource/bearer_spec.rb
@@ -65,6 +65,11 @@ describe Rack::OAuth2::Server::Resource::Bearer do
       let(:env) { Rack::MockRequest.env_for('/protected_resource', params: {access_token: 'valid_token'}) }
       it_behaves_like :authenticated_bearer_request
     end
+
+    context 'when token is in cookie' do
+      let(:env) { Rack::MockRequest.env_for('/protected_resource', 'HTTP_COOKIE' => 'Bearer=valid_token') }
+      it_behaves_like :authenticated_bearer_request
+    end
   end
 
   context 'when invalid authorization header is given' do
@@ -109,15 +114,16 @@ describe Rack::OAuth2::Server::Resource::Bearer do
   end
 
   context 'when multiple access_token is given' do
-    context 'when token is in Authorization header and params' do
+    context 'when token is in cookie, Authorization header and params' do
       let(:env) do
         Rack::MockRequest.env_for(
           '/protected_resource',
           'HTTP_AUTHORIZATION' => 'Bearer valid_token',
+          'HTTP_COOKIE' => 'Bearer=valid_token',
           params: {access_token: 'valid_token'}
         )
       end
-      it_behaves_like :bad_bearer_request
+      it_behaves_like :authenticated_bearer_request
     end
   end
 end


### PR DESCRIPTION
We have some use cases within our application, where we need to start a session from a mobile device. Due to limitations we need to transfer the token through cookies instead of a header or params. This PR adds the feature to read the token from the `Bearer` cookie in the request.