### PR TITLE
mTLS needs client secret for requests

### DIFF
--- a/lib/rack/oauth2/client.rb
+++ b/lib/rack/oauth2/client.rb
@@ -109,7 +109,8 @@ module Rack
           )
         when :mtls
           params.merge!(
-            client_id: identifier
+            client_id: identifier,
+            client_secret: secret
           )
           http_client.ssl_config.client_key = private_key
           http_client.ssl_config.client_cert = certificate


### PR DESCRIPTION
We tested this with ADP using omniauth_openid_connect.  Without the client secret for mTLS requests, we received "invalid_client".