### PR TITLE
Bump json-jwt to 1.11.0 (minimum) for security vulnerability fix

### DIFF
--- a/rack-oauth2.gemspec
+++ b/rack-oauth2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'httpclient'
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'attr_required'
-  s.add_runtime_dependency 'json-jwt', '>= 1.9.0'
+  s.add_runtime_dependency 'json-jwt', '>= 1.11.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
We received a Dependabot update for json-jwt 1.11.0 which included a security fix.

> Sourced from The GitHub Security Advisory Database.
>
> > **Moderate severity vulnerability that affects json-jwt**
> > The json-jwt gem before 1.11.0 for Ruby lacks an element count during the splitting of a JWE string.
> >
> > Affected versions: < 1.11.0

Since we rely on fb_graph2 and rack-oauth2 is a dependency of that gem, we figured it would help to bump the minimum json-jwt version here so others don't install vulnerable versions.