### PR TITLE
Change `spec.homepage` from HTTP to HTTPS

### DIFF
--- a/rack-oauth2.gemspec
+++ b/rack-oauth2.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email = 'nov@matake.jp'
   s.extra_rdoc_files = ['LICENSE', 'README.rdoc']
   s.rdoc_options = ['--charset=UTF-8']
-  s.homepage = 'http://github.com/nov/rack-oauth2'
+  s.homepage = 'https://github.com/nov/rack-oauth2'
   s.license = 'MIT'
   s.require_paths = ['lib']
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Now GitHub uses HTTPS by default. This is a tiny change but it reduces unnecessary redirection from HTTP to HTTPS
when someone is browsing the repository via https://rubygems.org/gems/rack-oauth2,
or some tools that use the gem's metadata.
