### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/rack-oauth2

### DIFF
--- a/rack-oauth2.gemspec
+++ b/rack-oauth2.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'rexml'
+  s.metadata["changelog_uri"] = s.homepage + "/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/rack-oauth2 which makes it quick and easy for someone to check on the changes introduced with a new version.

I chose to link to the '/releases' page since that has more details in it than the CHANGELOG.md in the source code repository.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/