### PR TITLE
Add support for resource_metadata in the WWW-Authenticate header

### DIFF
--- a/lib/rack/oauth2/server/abstract/error.rb
+++ b/lib/rack/oauth2/server/abstract/error.rb
@@ -3,7 +3,7 @@ module Rack
     module Server
       module Abstract
         class Error < StandardError
-          attr_accessor :status, :error, :description, :uri, :realm
+          attr_accessor :status, :error, :description, :uri, :realm, :resource_metadata
 
           def initialize(status, error, description = nil, options = {})
             @status      = status
@@ -11,6 +11,7 @@ module Rack
             @description = description
             @uri         = options[:uri]
             @realm       = options[:realm]
+            @resource_metadata = options[:resource_metadata]
             super [error, description].compact.join(' :: ')
           end
 

--- a/lib/rack/oauth2/server/resource/error.rb
+++ b/lib/rack/oauth2/server/resource/error.rb
@@ -19,6 +19,7 @@ module Rack
                 headers << ", error_description=\"#{description}\"" if description.present?
                 headers << ", error_uri=\"#{uri}\""                 if uri.present?
               end
+              headers << ", resource_metadata=\"#{resource_metadata}\"" if resource_metadata.present?
             end
           end
         end

--- a/spec/rack/oauth2/server/resource/error_spec.rb
+++ b/spec/rack/oauth2/server/resource/error_spec.rb
@@ -77,6 +77,17 @@ describe Rack::OAuth2::Server::Resource::Unauthorized do
           response.first.should include '"error":"something"'
         end
       end
+
+      context 'when resource_metadata is specified' do
+        let(:resource_metadata) { "https://resource.example.com/.well-known/oauth-protected-resource" }
+        let(:error) { Rack::OAuth2::Server::Resource::Bearer::Unauthorized.new(:something, nil, resource_metadata: resource_metadata) }
+
+        it 'should include resource_metadata in WWW-Authenticate header' do
+          _, headers, response = error_with_scheme.finish
+          headers['WWW-Authenticate'].should include %(resource_metadata="#{resource_metadata}")
+          response.first.should include '"error":"something"'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/rfc9728/

This specification introduces a new parameter in the WWW-Authenticate HTTP response header field to indicate the protected resource metadata URL:

   resource_metadata:
      The URL of the protected resource metadata.

The response below is an example of a WWW-Authenticate header that includes the resource identifier.

    HTTP/1.1 401 Unauthorized
    WWW-Authenticate: Bearer resource_metadata=
      "https://resource.example.com/.well-known/oauth-protected-resource"

The HTTP status code in the example response above is defined by [RFC6750].

This parameter MAY also be used in WWW-Authenticate responses using authorization schemes other than "Bearer" [RFC6750], such as the DPoP scheme defined by [RFC9449].

The resource_metadata parameter MAY be combined with other parameters defined in other extensions, such as the max_age parameter defined by [RFC9470].