### PR TITLE
Add support for endpoints requiring mTLS with HTTP Basic Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- add support for endpoints requiring mTLS with HTTP Basic Authentication
+
 ## [2.2.0] - 2022-10-11
 
 ### Changed

--- a/lib/rack/oauth2/client.rb
+++ b/lib/rack/oauth2/client.rb
@@ -182,6 +182,16 @@ module Rack
           )
           http_client.ssl.client_key = private_key
           http_client.ssl.client_cert = certificate
+        when :mtls_basic
+          http_client.ssl.client_key = private_key
+          http_client.ssl.client_cert = certificate
+          cred = Base64.strict_encode64 [
+            Util.www_form_url_encode(identifier),
+            Util.www_form_url_encode(secret)
+          ].join(':')
+          headers.merge!(
+            'Authorization' => "Basic #{cred}"
+          )
         else
           params.merge!(
             client_id: identifier,


### PR DESCRIPTION
We need this for ADP's OIDC IDP we're integrating with. The docs are not public anymore but https://stackoverflow.com/questions/67942972/powershell-adp-api-token lists this as the required implementation.